### PR TITLE
Add Vitest test for CartTotalCost

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - [Installation](#-installation)
 - [Environment Configuration](#-environment-configuration)
 - [Available Scripts](#-available-scripts)
+- [Running Tests](#-running-tests)
 - [Component Documentation](#-component-documentation)
 - [State Management](#-state-management)
 - [Styling Guide](#-styling-guide)
@@ -230,6 +231,21 @@ Runs ESLint to check for code quality issues.
 
 ### `npm run lint:fix` or `yarn lint:fix`
 Automatically fixes ESLint issues when possible.
+
+### `npm test`
+Runs the Vitest test suite using React Testing Library. Ensure dependencies are installed with `npm install` before running.
+
+---
+
+## 🧪 Running Tests
+
+After installing dependencies, execute:
+
+```bash
+npm test
+```
+
+This command runs the Vitest suite configured for React components.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
@@ -36,6 +37,10 @@
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^15.15.0",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "vitest": "^1.5.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.1.0",
+    "jsdom": "^24.0.0"
   }
 }

--- a/src/__tests__/CartTotalCost.test.jsx
+++ b/src/__tests__/CartTotalCost.test.jsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import CartTotalCost from '../Components/CartTotalCost.jsx';
+import { ContextShop } from '../Context/ContextShop.jsx';
+
+function renderWithContext(value) {
+  return render(
+    <ContextShop.Provider value={value}>
+      <CartTotalCost />
+    </ContextShop.Provider>
+  );
+}
+
+describe('CartTotalCost', () => {
+  it('displays formatted totals from context', () => {
+    const contextValue = {
+      currency: '$',
+      Postage_fee: 5,
+      GetCartTotal: () => 50,
+      CartProducts: { '1': { M: { quantity: 2 } } },
+      products: [{ _id: '1', price: 25 }]
+    };
+
+    renderWithContext(contextValue);
+
+    expect(screen.getByText('Sub-total')).toBeInTheDocument();
+    expect(screen.getByText('$50.00')).toBeInTheDocument();
+    expect(screen.getByText('Delivery Fee')).toBeInTheDocument();
+    expect(screen.getByText('$5.00')).toBeInTheDocument();
+    expect(screen.getByText('Total')).toBeInTheDocument();
+    expect(screen.getByText('$55.00')).toBeInTheDocument();
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,7 @@
 import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
+import { configDefaults } from 'vitest/config';
 
 export default defineConfig(({ mode }) => {
   // Load env variables based on the current mode (e.g., development)
@@ -14,5 +15,10 @@ export default defineConfig(({ mode }) => {
     server: {
       port: 5173,
     },
+    test: {
+      environment: 'jsdom',
+      setupFiles: './vitest.setup.js',
+      exclude: [...configDefaults.exclude, 'e2e/**']
+    }
   };
 });

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- set up Vitest with React Testing Library
- configure Vitest in `vite.config.js`
- add `vitest.setup.js` for jest-dom
- create `CartTotalCost` test
- document testing in README
- add `npm test` script and dev dependencies

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884de6e7494832fad663025ae9a33b7